### PR TITLE
Remove security properties from generated apps

### DIFF
--- a/spring-cloud-stream-app-maven-plugin/src/main/java/org/springframework/cloud/stream/app/plugin/SpringCloudStreamAppMojo.java
+++ b/spring-cloud-stream-app-maven-plugin/src/main/java/org/springframework/cloud/stream/app/plugin/SpringCloudStreamAppMojo.java
@@ -284,13 +284,10 @@ public class SpringCloudStreamAppMojo extends AbstractMojo {
 				orderedStarterArtifactTokens.addAll(Stream.of(tokens)
 						.limit(tokens.length - 1)
 						.collect(toList()));
-				String applicationName = orderedStarterArtifactTokens.stream().collect(Collectors.joining("-"));
 
 				final File applicationProperties = new File(generatedAppHome, "src/main/resources/application.properties");
 
-				String applicationPropertiesContents = "management.context-path=" + "/management\n" +
-						"security.basic.path=" + "/management/**\n" +
-						"info.app.name=" + "@project.artifactId@" + "\n" +
+				String applicationPropertiesContents = "info.app.name=" + "@project.artifactId@" + "\n" +
 						"info.app.description=" + "@project.description@" + "\n" +
 						"info.app.version=" + "@project.version@" + "\n";
 


### PR DESCRIPTION
These two properties are no longer included in the generated apps: management.context-path and security.basic.path