### PR TITLE
Remove args param from shell entry point

### DIFF
--- a/spring-cloud-stream-app-maven-plugin/src/main/java/org/springframework/cloud/stream/app/plugin/utils/MavenModelUtils.java
+++ b/spring-cloud-stream-app-maven-plugin/src/main/java/org/springframework/cloud/stream/app/plugin/utils/MavenModelUtils.java
@@ -204,7 +204,7 @@ public class MavenModelUtils {
 
         if (ENTRYPOINT_TYPE_SHELL.equalsIgnoreCase(entrypointStyle)) {
             final Xpp3Dom shell = new Xpp3Dom(ENTRYPOINT_TYPE_SHELL);
-            shell.setValue("java $JAVA_OPTS -jar /maven/" + artifactId + ".jar ${*}");
+            shell.setValue("java $JAVA_OPTS -jar /maven/" + artifactId + ".jar");
             entryPoint.addChild(shell);
         } else {
             final Xpp3Dom exec = new Xpp3Dom(ENTRYPOINT_TYPE_EXEC);


### PR DESCRIPTION
trailing args won't be added when using `shell` entry point syntax so `${*}` should be removed. this was requested in the original contribution but looks like it made it by