### PR TITLE
Now starters can add additional properties to application.properties

### DIFF
--- a/spring-cloud-stream-app-maven-plugin/README.adoc
+++ b/spring-cloud-stream-app-maven-plugin/README.adoc
@@ -65,7 +65,7 @@ Extra dependency management can be added as additional boms to the plugin using 
 
 
 ==== Copy Third-Party Resources
-The `copyResources` configuration bock permits coping Resources from third-party jar dependencies into the
+The `copyResources` configuration block permits copying Resources from third-party jar dependencies into the
 generated App Starter classpath.
 
 Form example if you want to copy a truststore and a self-signed certificate (`clientKeyStore.jks`, `cacerts`)  bundled inside the
@@ -124,4 +124,27 @@ Later will add the following `maven-dependency-plugin` definition to the generat
       </plugin>
 ----
 
-This will ensure that the clientKeyStore.jks,cacerts files will be pied to the AppStarter's `BOOT-INF/classes/`
+This will ensure that the clientKeyStore.jks,cacerts files will be copied to the AppStarter's `BOOT-INF/classes/`
+
+==== Insert additional properties into the application.properties file for the created app.
+The `additionalAppProperties` configuration block permits adding of additional properties to the application.properties file.
+[source, xml]
+----
+<plugin>
+    <groupId>org.springframework.cloud.stream.app.plugin</groupId>
+    <artifactId>spring-cloud-stream-app-maven-plugin</artifactId>
+    <configuration>
+        <generatedProjectHome>${session.executionRootDirectory}/apps</generatedProjectHome>
+        <generatedProjectVersion>${project.version}</generatedProjectVersion>
+        <bom>....</bom>
+        <generatedApps>
+            <coap-server-source/>
+        </generatedApps>
+        <additionalAppProperties>
+            <additionalAppProperty>spring.cloud.task.closecontextEnabled=true</additionalAppProperty>
+        </additionalAppProperties>
+    </configuration>
+    </configuration>
+</plugin>
+----
+In the example above we added the`spring.cloud.task.closecontextEnabled` property to the application.properties of the created app.

--- a/spring-cloud-stream-app-maven-plugin/src/main/java/org/springframework/cloud/stream/app/plugin/SpringCloudStreamAppMojo.java
+++ b/spring-cloud-stream-app-maven-plugin/src/main/java/org/springframework/cloud/stream/app/plugin/SpringCloudStreamAppMojo.java
@@ -16,6 +16,24 @@
 
 package org.springframework.cloud.stream.app.plugin;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import io.spring.initializr.generator.ProjectRequest;
 import io.spring.initializr.metadata.Dependency;
 import io.spring.initializr.metadata.InitializrMetadata;
@@ -30,21 +48,12 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+
 import org.springframework.cloud.stream.app.plugin.utils.MavenModelUtils;
 import org.springframework.cloud.stream.app.plugin.utils.SpringCloudStreamPluginUtils;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.util.CollectionUtils;
-
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
 import static org.springframework.cloud.stream.app.plugin.utils.MavenModelUtils.ENTRYPOINT_TYPE_EXEC;
@@ -53,6 +62,7 @@ import static org.springframework.cloud.stream.app.plugin.utils.MavenModelUtils.
 /**
  * @author Soby Chacko
  * @author Christian Tzolov
+ * @author Glenn Renfro
  */
 @Mojo(name = "generate-app")
 public class SpringCloudStreamAppMojo extends AbstractMojo {
@@ -109,6 +119,9 @@ public class SpringCloudStreamAppMojo extends AbstractMojo {
 
 	@Parameter
 	List<Plugin> additionalPlugins = new ArrayList<>();
+
+	@Parameter
+	List<String> additionalAppProperties;
 
 	@Parameter
 	private List<Dependency> requiresUnpack = new ArrayList<>();
@@ -309,6 +322,11 @@ public class SpringCloudStreamAppMojo extends AbstractMojo {
 						"info.app.version=" + "@project.version@" + "\n" +
 						"management.endpoints.web.exposure.include=health,info,bindings" + "\n" +
 						"spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration" + "\n";
+				if(this.additionalAppProperties != null && !this.additionalAppProperties.isEmpty()){
+					for(String property : this.additionalAppProperties) {
+						applicationPropertiesContents = applicationPropertiesContents.concat(String.format("%s\n", property));
+					}
+				}
 				Files.write(applicationProperties.toPath(), applicationPropertiesContents.getBytes());
 			}
 			catch (IOException e) {

--- a/spring-cloud-stream-app-maven-plugin/src/test/java/org/springframework/cloud/stream/app/plugin/SpringCloudStreamAppMojoTest.java
+++ b/spring-cloud-stream-app-maven-plugin/src/test/java/org/springframework/cloud/stream/app/plugin/SpringCloudStreamAppMojoTest.java
@@ -154,7 +154,6 @@ public class SpringCloudStreamAppMojoTest {
 
     @Test
     public void testAppPropertiesWithAppProp() throws Exception {
-
         final String ENTRY_ONE = "hello=world";
         final String ENTRY_TWO = "foo=bar";
         Field generatedProjectHome = this.mojoClazz.getDeclaredField("generatedProjectHome");
@@ -173,6 +172,28 @@ public class SpringCloudStreamAppMojoTest {
         this.appPropertyValues.add(ENTRY_TWO);
         validateApplicationProperties(8);
     }
+
+
+    @Test
+    public void testAppPropertiesWithExistingProps() throws Exception {
+        final String ENTRY_ONE = "spring.application.name =foo";
+        final String ENTRY_TWO = "foo=bar";
+        Field generatedProjectHome = this.mojoClazz.getDeclaredField("generatedProjectHome");
+        generatedProjectHome.setAccessible(true);
+        ReflectionUtils.setField(generatedProjectHome, this.springCloudStreamAppMojo, this.projectHome);
+        Field appPropertiesField = this.mojoClazz.getDeclaredField("additionalAppProperties");
+        appPropertiesField.setAccessible(true);
+        List<String> appProperties = new ArrayList<>();
+        appProperties.add(ENTRY_ONE);
+        appProperties.add(ENTRY_TWO);
+        ReflectionUtils.setField(appPropertiesField, this.springCloudStreamAppMojo, appProperties);
+
+        this.springCloudStreamAppMojo.execute();
+
+        this.appPropertyValues.add(ENTRY_TWO);
+        validateApplicationProperties(7);
+    }
+
 
     private void validateApplicationProperties(int expectedCount) throws Exception{
         Stream<Path> pathStream =


### PR DESCRIPTION
Users need the ability to add properties to the application.properties of the generated app.

Resolves spring-cloud-task-app-starters/composed-task-runner#46
resolves #34