### PR TITLE
Data flow whitelist file changes in metadata plugin

### DIFF
--- a/spring-cloud-app-starter-metadata-maven-plugin/src/main/java/org/springframework/cloud/stream/app/documentation/plugin/MetadataAggregationMojo.java
+++ b/spring-cloud-app-starter-metadata-maven-plugin/src/main/java/org/springframework/cloud/stream/app/documentation/plugin/MetadataAggregationMojo.java
@@ -76,7 +76,8 @@ import static org.springframework.boot.configurationprocessor.metadata.ItemHint.
 public class MetadataAggregationMojo extends AbstractMojo {
 
 	static final String METADATA_PATH = "META-INF/spring-configuration-metadata.json";
-	static final String WHITELIST_PATH = "META-INF/spring-configuration-metadata-whitelist.properties";
+	static final String WHITELIST_PATH = "META-INF/dataflow-configuration-metadata-whitelist.properties";
+	static final String BACKUP_WHITELIST_PATH = "META-INF/spring-configuration-metadata-whitelist.properties";
 	static final String CONFIGURATION_PROPERTIES_CLASSES = "configuration-properties.classes";
 	static final String CONFIGURATION_PROPERTIES_NAMES = "configuration-properties.names";
 
@@ -139,6 +140,15 @@ public class MetadataAggregationMojo extends AbstractMojo {
 							whiteList = merge(whiteList, is);
 						}
 					}
+					else {
+						File backupLocalWhiteList = new File(file, BACKUP_WHITELIST_PATH);
+						if (backupLocalWhiteList.canRead()) {
+							try (InputStream is = new FileInputStream(backupLocalWhiteList)) {
+								getLog().debug("!!!! Merging whitelist from " + path);
+								whiteList = merge(whiteList, is);
+							}
+						}
+					}
 				}
 				else {
 					try (ZipFile zipFile = new ZipFile(file)) {
@@ -156,6 +166,15 @@ public class MetadataAggregationMojo extends AbstractMojo {
 							try (InputStream inputStream = zipFile.getInputStream(entry)) {
 								getLog().debug("Merging whitelist from " + path);
 								whiteList = merge(whiteList, inputStream);
+							}
+						}
+						else {
+							entry = zipFile.getEntry(BACKUP_WHITELIST_PATH);
+							if (entry != null) {
+								try (InputStream inputStream = zipFile.getInputStream(entry)) {
+									getLog().debug("Merging whitelist from " + path);
+									whiteList = merge(whiteList, inputStream);
+								}
 							}
 						}
 					}

--- a/spring-cloud-app-starter-metadata-maven-plugin/src/main/java/org/springframework/cloud/stream/app/documentation/plugin/MetadataAggregationMojo.java
+++ b/spring-cloud-app-starter-metadata-maven-plugin/src/main/java/org/springframework/cloud/stream/app/documentation/plugin/MetadataAggregationMojo.java
@@ -27,13 +27,10 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 import java.util.jar.JarOutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -135,18 +132,12 @@ public class MetadataAggregationMojo extends AbstractMojo {
 					}
 					File localWhiteList = new File(file, WHITELIST_PATH);
 					if (localWhiteList.canRead()) {
-						try (InputStream is = new FileInputStream(localWhiteList)) {
-							getLog().debug("!!!! Merging whitelist from " + path);
-							whiteList = merge(whiteList, is);
-						}
+						whiteList = getWhitelistFromFile(whiteList, path, localWhiteList);
 					}
 					else {
 						File backupLocalWhiteList = new File(file, BACKUP_WHITELIST_PATH);
 						if (backupLocalWhiteList.canRead()) {
-							try (InputStream is = new FileInputStream(backupLocalWhiteList)) {
-								getLog().debug("!!!! Merging whitelist from " + path);
-								whiteList = merge(whiteList, is);
-							}
+							whiteList = getWhitelistFromFile(whiteList, path, backupLocalWhiteList);
 						}
 					}
 				}
@@ -163,18 +154,12 @@ public class MetadataAggregationMojo extends AbstractMojo {
 						}
 						entry = zipFile.getEntry(WHITELIST_PATH);
 						if (entry != null) {
-							try (InputStream inputStream = zipFile.getInputStream(entry)) {
-								getLog().debug("Merging whitelist from " + path);
-								whiteList = merge(whiteList, inputStream);
-							}
+							whiteList = getWhitelistFromZipFile(whiteList, path, zipFile, entry);
 						}
 						else {
 							entry = zipFile.getEntry(BACKUP_WHITELIST_PATH);
 							if (entry != null) {
-								try (InputStream inputStream = zipFile.getInputStream(entry)) {
-									getLog().debug("Merging whitelist from " + path);
-									whiteList = merge(whiteList, inputStream);
-								}
+								whiteList = getWhitelistFromZipFile(whiteList, path, zipFile, entry);
 							}
 						}
 					}
@@ -185,6 +170,22 @@ public class MetadataAggregationMojo extends AbstractMojo {
 			throw new MojoExecutionException("Exception trying to read metadata from dependencies of project", e);
 		}
 		return new Result(metadata, whiteList);
+	}
+
+	private Properties getWhitelistFromZipFile(Properties whiteList, String path, ZipFile zipFile, ZipEntry entry) throws IOException {
+		try (InputStream inputStream = zipFile.getInputStream(entry)) {
+			getLog().debug("Merging whitelist from " + path);
+			whiteList = merge(whiteList, inputStream);
+		}
+		return whiteList;
+	}
+
+	private Properties getWhitelistFromFile(Properties whiteList, String path, File localWhiteList) throws IOException {
+		try (InputStream is = new FileInputStream(localWhiteList)) {
+			getLog().debug("!!!! Merging whitelist from " + path);
+			whiteList = merge(whiteList, is);
+		}
+		return whiteList;
 	}
 
 	Properties merge(Properties whitelist, InputStream is) throws IOException {


### PR DESCRIPTION
Use dataflow specific whitelist properties file in metadata generation.
If the new file is missing, fall back to the old file.

Resolves #42