### PR TITLE
URL Cleanup

### DIFF
--- a/spring-cloud-app-starter-doc-maven-plugin/mvnw
+++ b/spring-cloud-app-starter-doc-maven-plugin/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/spring-cloud-app-starter-doc-maven-plugin/mvnw.cmd
+++ b/spring-cloud-app-starter-doc-maven-plugin/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/spring-cloud-app-starter-doc-maven-plugin/pom.xml
+++ b/spring-cloud-app-starter-doc-maven-plugin/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
@@ -57,7 +57,7 @@
 					</snapshots>
 					<id>spring-snapshots</id>
 					<name>Spring Snapshots</name>
-					<url>http://repo.spring.io/libs-snapshot-local</url>
+					<url>https://repo.spring.io/libs-snapshot-local</url>
 				</repository>
 				<repository>
 					<snapshots>
@@ -65,7 +65,7 @@
 					</snapshots>
 					<id>spring-milestones</id>
 					<name>Spring Milestones</name>
-					<url>http://repo.spring.io/libs-milestone-local</url>
+					<url>https://repo.spring.io/libs-milestone-local</url>
 				</repository>
 				<repository>
 					<snapshots>
@@ -73,7 +73,7 @@
 					</snapshots>
 					<id>spring-releases</id>
 					<name>Spring Releases</name>
-					<url>http://repo.spring.io/release</url>
+					<url>https://repo.spring.io/release</url>
 				</repository>
 				<repository>
 					<snapshots>
@@ -81,7 +81,7 @@
 					</snapshots>
 					<id>spring-libs-release</id>
 					<name>Spring Libs Release</name>
-					<url>http://repo.spring.io/libs-release</url>
+					<url>https://repo.spring.io/libs-release</url>
 				</repository>
 				<repository>
 					<snapshots>
@@ -89,7 +89,7 @@
 					</snapshots>
 					<id>spring-milestone-release</id>
 					<name>Spring Milestone Release</name>
-					<url>http://repo.spring.io/libs-milestone</url>
+					<url>https://repo.spring.io/libs-milestone</url>
 				</repository>
 			</repositories>
 			<pluginRepositories>
@@ -99,7 +99,7 @@
 					</snapshots>
 					<id>spring-snapshots</id>
 					<name>Spring Snapshots</name>
-					<url>http://repo.spring.io/libs-snapshot-local</url>
+					<url>https://repo.spring.io/libs-snapshot-local</url>
 				</pluginRepository>
 				<pluginRepository>
 					<snapshots>
@@ -107,7 +107,7 @@
 					</snapshots>
 					<id>spring-milestones</id>
 					<name>Spring Milestones</name>
-					<url>http://repo.spring.io/libs-milestone-local</url>
+					<url>https://repo.spring.io/libs-milestone-local</url>
 				</pluginRepository>
 			</pluginRepositories>
 		</profile>

--- a/spring-cloud-app-starter-metadata-maven-plugin/mvnw
+++ b/spring-cloud-app-starter-metadata-maven-plugin/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/spring-cloud-app-starter-metadata-maven-plugin/mvnw.cmd
+++ b/spring-cloud-app-starter-metadata-maven-plugin/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/spring-cloud-app-starter-metadata-maven-plugin/pom.xml
+++ b/spring-cloud-app-starter-metadata-maven-plugin/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
@@ -50,7 +50,7 @@
 					</snapshots>
 					<id>spring-snapshots</id>
 					<name>Spring Snapshots</name>
-					<url>http://repo.spring.io/libs-snapshot-local</url>
+					<url>https://repo.spring.io/libs-snapshot-local</url>
 				</repository>
 				<repository>
 					<snapshots>
@@ -58,7 +58,7 @@
 					</snapshots>
 					<id>spring-milestones</id>
 					<name>Spring Milestones</name>
-					<url>http://repo.spring.io/libs-milestone-local</url>
+					<url>https://repo.spring.io/libs-milestone-local</url>
 				</repository>
 				<repository>
 					<snapshots>
@@ -66,7 +66,7 @@
 					</snapshots>
 					<id>spring-releases</id>
 					<name>Spring Releases</name>
-					<url>http://repo.spring.io/release</url>
+					<url>https://repo.spring.io/release</url>
 				</repository>
 				<repository>
 					<snapshots>
@@ -74,7 +74,7 @@
 					</snapshots>
 					<id>spring-libs-release</id>
 					<name>Spring Libs Release</name>
-					<url>http://repo.spring.io/libs-release</url>
+					<url>https://repo.spring.io/libs-release</url>
 				</repository>
 				<repository>
 					<snapshots>
@@ -82,7 +82,7 @@
 					</snapshots>
 					<id>spring-milestone-release</id>
 					<name>Spring Milestone Release</name>
-					<url>http://repo.spring.io/libs-milestone</url>
+					<url>https://repo.spring.io/libs-milestone</url>
 				</repository>
 			</repositories>
 			<pluginRepositories>
@@ -92,7 +92,7 @@
 					</snapshots>
 					<id>spring-snapshots</id>
 					<name>Spring Snapshots</name>
-					<url>http://repo.spring.io/libs-snapshot-local</url>
+					<url>https://repo.spring.io/libs-snapshot-local</url>
 				</pluginRepository>
 				<pluginRepository>
 					<snapshots>
@@ -100,7 +100,7 @@
 					</snapshots>
 					<id>spring-milestones</id>
 					<name>Spring Milestones</name>
-					<url>http://repo.spring.io/libs-milestone-local</url>
+					<url>https://repo.spring.io/libs-milestone-local</url>
 				</pluginRepository>
 			</pluginRepositories>
 		</profile>

--- a/spring-cloud-stream-app-maven-plugin/mvnw
+++ b/spring-cloud-stream-app-maven-plugin/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/spring-cloud-stream-app-maven-plugin/mvnw.cmd
+++ b/spring-cloud-stream-app-maven-plugin/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/spring-cloud-stream-app-maven-plugin/pom.xml
+++ b/spring-cloud-stream-app-maven-plugin/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.springframework.cloud.stream.app.plugin</groupId>
@@ -10,16 +10,16 @@
 
   <name>spring-cloud-stream-app-maven-plugin Maven Plugin</name>
 
-  <url>http://spring.io</url>
+  <url>https://spring.io</url>
 
   <organization>
     <name>Pivotal Software, Inc.</name>
-    <url>http://www.spring.io</url>
+    <url>https://www.spring.io</url>
   </organization>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0</url>
       <comments>
         Copyright 2014-2016 the original author or authors.
 
@@ -27,7 +27,7 @@
         you may not use this file except in compliance with the License.
         You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,
@@ -57,7 +57,7 @@
       <name>Soby Chacko</name>
       <email>schacko at pivotal.io</email>
       <organization>Pivotal Software, Inc.</organization>
-      <organizationUrl>http://www.spring.io</organizationUrl>
+      <organizationUrl>https://www.spring.io</organizationUrl>
       <roles>
         <role>Developer</role>
       </roles>
@@ -257,7 +257,7 @@
       </snapshots>
       <id>spring-snapshots</id>
       <name>Spring Snapshots</name>
-      <url>http://repo.spring.io/libs-snapshot-local</url>
+      <url>https://repo.spring.io/libs-snapshot-local</url>
     </repository>
     <repository>
       <snapshots>
@@ -265,7 +265,7 @@
       </snapshots>
       <id>spring-milestones</id>
       <name>Spring Milestones</name>
-      <url>http://repo.spring.io/libs-milestone-local</url>
+      <url>https://repo.spring.io/libs-milestone-local</url>
     </repository>
     <repository>
       <snapshots>
@@ -273,7 +273,7 @@
       </snapshots>
       <id>spring-releases</id>
       <name>Spring Releases</name>
-      <url>http://repo.spring.io/release</url>
+      <url>https://repo.spring.io/release</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://maven.apache.org/xsd/maven-4.0.0.xsd with 3 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://spring.io with 1 occurrences migrated to:  
  https://spring.io ([https](https://spring.io) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 with 8 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://www.spring.io with 2 occurrences migrated to:  
  https://www.spring.io ([https](https://www.spring.io) result 301).
* http://repo.spring.io/libs-milestone with 2 occurrences migrated to:  
  https://repo.spring.io/libs-milestone ([https](https://repo.spring.io/libs-milestone) result 302).
* http://repo.spring.io/libs-milestone-local with 5 occurrences migrated to:  
  https://repo.spring.io/libs-milestone-local ([https](https://repo.spring.io/libs-milestone-local) result 302).
* http://repo.spring.io/libs-release with 2 occurrences migrated to:  
  https://repo.spring.io/libs-release ([https](https://repo.spring.io/libs-release) result 302).
* http://repo.spring.io/libs-snapshot-local with 5 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot-local ([https](https://repo.spring.io/libs-snapshot-local) result 302).
* http://repo.spring.io/release with 3 occurrences migrated to:  
  https://repo.spring.io/release ([https](https://repo.spring.io/release) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 6 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 3 occurrences