### PR TITLE
URL Cleanup

### DIFF
--- a/spring-cloud-app-starter-doc-maven-plugin/README.adoc
+++ b/spring-cloud-app-starter-doc-maven-plugin/README.adoc
@@ -3,7 +3,7 @@
 Maven plugin for generating documentation for Spring Cloud stream and task app starters.
 
 Assuming a Spring Cloud Stream / Task app (or app starter) has
-http://docs.spring.io/spring-cloud-dataflow/docs/1.1.0.M2/reference/html/spring-cloud-dataflow-register-apps.html#spring-cloud-dataflow-stream-app-whitelisting[whitelisted]
+https://docs.spring.io/spring-cloud-dataflow/docs/1.1.0.M2/reference/html/spring-cloud-dataflow-register-apps.html#spring-cloud-dataflow-stream-app-whitelisting[whitelisted]
 some configuration properties, this plugin will help automate the documentation of such properties.
 
 == Usage

--- a/spring-cloud-app-starter-doc-maven-plugin/src/main/java/org/springframework/cloud/stream/app/documentation/plugin/ConfigurationMetadataDocumentationMojo.java
+++ b/spring-cloud-app-starter-doc-maven-plugin/src/main/java/org/springframework/cloud/stream/app/documentation/plugin/ConfigurationMetadataDocumentationMojo.java
@@ -58,7 +58,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Eric Bottard
  * @see <a href=
- * "http://docs.spring.io/spring-cloud-dataflow/docs/1.1.0.M2/reference/html/spring-cloud-dataflow-register-apps.html#spring-cloud-dataflow-stream-app-whitelisting">Whitelisting
+ * "https://docs.spring.io/spring-cloud-dataflow/docs/1.1.0.M2/reference/html/spring-cloud-dataflow-register-apps.html#spring-cloud-dataflow-stream-app-whitelisting">Whitelisting
  * Properties</a>
  */
 @Mojo(name = "generate-documentation", requiresDependencyResolution = ResolutionScope.RUNTIME)

--- a/spring-cloud-stream-app-maven-plugin/src/main/java/org/springframework/cloud/stream/app/plugin/utils/MavenModelUtils.java
+++ b/spring-cloud-stream-app-maven-plugin/src/main/java/org/springframework/cloud/stream/app/plugin/utils/MavenModelUtils.java
@@ -78,7 +78,7 @@ public class MavenModelUtils {
 
             model.setName("Apps Container");
             model.setDescription("Container project for generated apps");
-            model.setUrl("http://spring.io/spring-cloud");
+            model.setUrl("https://spring.io/spring-cloud");
             License license = new License();
             license.setName("Apache License, Version 2.0");
             license.setUrl("http://www.apache.org/licenses/LICENSE-2.0");
@@ -111,7 +111,7 @@ public class MavenModelUtils {
             developer.setName("Soby Chacko");
             developer.setEmail("schacko at pivotal.io");
             developer.setOrganization("Pivotal Software, Inc.");
-            developer.setOrganizationUrl("http://www.spring.io");
+            developer.setOrganizationUrl("https://www.spring.io");
             List<String> roles = new ArrayList<>();
             roles.add("developer");
             developer.setRoles(roles);
@@ -258,7 +258,7 @@ public class MavenModelUtils {
         org.apache.maven.model.Repository pluginRepo1 = new org.apache.maven.model.Repository();
         pluginRepo1.setId("spring-snapshots");
         pluginRepo1.setName("Spring Snapshots");
-        pluginRepo1.setUrl("http://repo.spring.io/libs-snapshot-local");
+        pluginRepo1.setUrl("https://repo.spring.io/libs-snapshot-local");
         pluginRepo1.setSnapshots(repositoryPolicy1);
 
         RepositoryPolicy repositoryPolicy2 = new RepositoryPolicy();
@@ -267,7 +267,7 @@ public class MavenModelUtils {
         pluginRepo2.setId("spring-milestones");
         pluginRepo2.setName("Spring Milestones");
         pluginRepo2.setSnapshots(repositoryPolicy2);
-        pluginRepo2.setUrl("http://repo.spring.io/libs-milestone-local");
+        pluginRepo2.setUrl("https://repo.spring.io/libs-milestone-local");
 
         List<Repository> pluginRepositories = pomModel.getPluginRepositories();
         if (!pluginRepositories.contains(pluginRepo1)){


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-cloud-dataflow/docs/1.1.0.M2/reference/html/spring-cloud-dataflow-register-apps.html with 2 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-dataflow/docs/1.1.0.M2/reference/html/spring-cloud-dataflow-register-apps.html ([https](https://docs.spring.io/spring-cloud-dataflow/docs/1.1.0.M2/reference/html/spring-cloud-dataflow-register-apps.html) result 200).
* [ ] http://www.spring.io with 1 occurrences migrated to:  
  https://www.spring.io ([https](https://www.spring.io) result 301).
* [ ] http://repo.spring.io/libs-milestone-local with 1 occurrences migrated to:  
  https://repo.spring.io/libs-milestone-local ([https](https://repo.spring.io/libs-milestone-local) result 302).
* [ ] http://repo.spring.io/libs-snapshot-local with 1 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot-local ([https](https://repo.spring.io/libs-snapshot-local) result 302).
* [ ] http://spring.io/spring-cloud with 1 occurrences migrated to:  
  https://spring.io/spring-cloud ([https](https://spring.io/spring-cloud) result 302).