### PR TITLE
Allow more generic use of Maven Plugin for non Spring Cloud projects

### DIFF
--- a/spring-cloud-stream-app-maven-plugin/src/main/java/org/springframework/cloud/stream/app/plugin/ScsProjectGenerator.java
+++ b/spring-cloud-stream-app-maven-plugin/src/main/java/org/springframework/cloud/stream/app/plugin/ScsProjectGenerator.java
@@ -75,7 +75,7 @@ public class ScsProjectGenerator extends ProjectGenerator {
         try {
             final InputStream is = new FileInputStream(inputFile);
             final OutputStream os = new FileOutputStream(tempOutputFile1);
-            MavenModelUtils.addDockerPlugin(request.getArtifactId(), request.getVersion(), dockerHubOrg, is, os, entrypointType);
+            MavenModelUtils.addDockerPlugin(request.getArtifactId(), request.getVersion(), is, os, entrypointType);
 
             FileInputStream is1 = new FileInputStream(tempOutputFile1);
             FileOutputStream os1 = new FileOutputStream(tempOutputFile2);

--- a/spring-cloud-stream-app-maven-plugin/src/main/java/org/springframework/cloud/stream/app/plugin/ScsProjectGenerator.java
+++ b/spring-cloud-stream-app-maven-plugin/src/main/java/org/springframework/cloud/stream/app/plugin/ScsProjectGenerator.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.stream.app.plugin;
 import io.spring.initializr.generator.ProjectGenerator;
 import io.spring.initializr.generator.ProjectRequest;
 import io.spring.initializr.metadata.Dependency;
+import org.apache.maven.model.DistributionManagement;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
@@ -50,6 +51,8 @@ public class ScsProjectGenerator extends ProjectGenerator {
     private List<Plugin> additionalPlugins;
 
     private List<Dependency> requiresUnpack;
+
+    private DistributionManagement distributionManagement;
 
     @Override
     protected File doGenerateProjectStructure(ProjectRequest request) {
@@ -113,7 +116,7 @@ public class ScsProjectGenerator extends ProjectGenerator {
                 MavenModelUtils.addAdditionalBoms(pomModel, additionalBoms);
             }
             MavenModelUtils.addExclusionsForKafka(pomModel);
-            MavenModelUtils.addDistributionManagement(pomModel);
+            MavenModelUtils.addDistributionManagement(pomModel, distributionManagement);
             MavenModelUtils.addProfiles(pomModel);
             MavenModelUtils.addProperties(pomModel, properties);
             MavenModelUtils.writeModelToFile(pomModel, os1);
@@ -156,5 +159,9 @@ public class ScsProjectGenerator extends ProjectGenerator {
 
     public void setRequiresUnpack(List<Dependency> requiresUnpack) {
         this.requiresUnpack = requiresUnpack;
+    }
+
+    public void setDistributionManagement(DistributionManagement distributionManagement) {
+        this.distributionManagement = distributionManagement;
     }
 }

--- a/spring-cloud-stream-app-maven-plugin/src/main/java/org/springframework/cloud/stream/app/plugin/SpringCloudStreamAppMojo.java
+++ b/spring-cloud-stream-app-maven-plugin/src/main/java/org/springframework/cloud/stream/app/plugin/SpringCloudStreamAppMojo.java
@@ -38,6 +38,7 @@ import io.spring.initializr.generator.ProjectRequest;
 import io.spring.initializr.metadata.Dependency;
 import io.spring.initializr.metadata.InitializrMetadata;
 import org.apache.commons.io.FileUtils;
+import org.apache.maven.model.DistributionManagement;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.AbstractMojo;
@@ -141,6 +142,9 @@ public class SpringCloudStreamAppMojo extends AbstractMojo {
 	@Parameter
 	private List<Dependency> requiresUnpack = new ArrayList<>();
 
+	@Parameter
+	private DistributionManagement distributionManagement;
+
 	private ScsProjectGenerator projectGenerator = new ScsProjectGenerator();
 
 	public void execute() throws MojoExecutionException, MojoFailureException {
@@ -168,6 +172,8 @@ public class SpringCloudStreamAppMojo extends AbstractMojo {
 		projectGenerator.setAdditionalBoms(additionalBoms);
 		projectGenerator.setAdditionalPlugins(additionalPlugins);
 		projectGenerator.setRequiresUnpack(requiresUnpack);
+		projectGenerator.setDistributionManagement(distributionManagement);
+
 		if (project != null) {
 			@SuppressWarnings("unchecked")
 			List<MavenProject> collectedProjects = project.getParent().getCollectedProjects();
@@ -561,6 +567,14 @@ public class SpringCloudStreamAppMojo extends AbstractMojo {
 				throw new IllegalStateException(e);
 			}
 		}
+	}
+
+	public DistributionManagement getDistributionManagement() {
+		return distributionManagement;
+	}
+
+	public void setDistributionManagement(DistributionManagement distributionManagement) {
+		this.distributionManagement = distributionManagement;
 	}
 
 	private class InitializrDelegate {

--- a/spring-cloud-stream-app-maven-plugin/src/main/java/org/springframework/cloud/stream/app/plugin/SpringCloudStreamAppMojo.java
+++ b/spring-cloud-stream-app-maven-plugin/src/main/java/org/springframework/cloud/stream/app/plugin/SpringCloudStreamAppMojo.java
@@ -334,7 +334,7 @@ public class SpringCloudStreamAppMojo extends AbstractMojo {
 											 File generatedProjectHome, String origKey, String generatedProjectVersion) throws IOException, XmlPullParserException {
 		if (generatedProjectHome != null && project != null) {
 			String generatedAppHome = moveProjectWithMavenModelsUpdated(appArtifactId, project, generatedProjectHome,
-					value.isTestsIgnored(), generatedProjectVersion, value);
+					value.isTestsIgnored(), generatedProjectVersion, value, distributionManagement);
 			try {
 				final File applicationProperties = new File(generatedAppHome, "src/main/resources/application.properties");
 				String applicationPropertiesContents = SPRING_APPLICATION_NAME + "=${vcap.application.name:" + origKey + "}\n" +
@@ -520,11 +520,11 @@ public class SpringCloudStreamAppMojo extends AbstractMojo {
 
 	private String moveProjectWithMavenModelsUpdated(String key, File project,
 													 File generatedProjectHome, boolean testIgnored,
-													 String generatedProjectVersion, GeneratableApp app) throws IOException, XmlPullParserException {
+													 String generatedProjectVersion, GeneratableApp app, DistributionManagement distributionManagement) throws IOException, XmlPullParserException {
 
 		Model model = isNewDir(generatedProjectHome) ? MavenModelUtils.populateModel(generatedProjectHome.getName(),
 				getApplicationGroupId(applicationType, app), generatedProjectVersion)
-				: MavenModelUtils.getModelFromContainerPom(generatedProjectHome, getApplicationGroupId(applicationType, app), generatedProjectVersion);
+				: MavenModelUtils.getModelFromContainerPom(generatedProjectHome, getApplicationGroupId(applicationType, app), generatedProjectVersion, distributionManagement);
 
 		if (model != null && MavenModelUtils.addModuleIntoModel(model, key)) {
 			MavenModelUtils.writeModelToFile(model, new FileOutputStream(new File(generatedProjectHome, "pom.xml")));

--- a/spring-cloud-stream-app-maven-plugin/src/main/java/org/springframework/cloud/stream/app/plugin/SpringCloudStreamAppMojo.java
+++ b/spring-cloud-stream-app-maven-plugin/src/main/java/org/springframework/cloud/stream/app/plugin/SpringCloudStreamAppMojo.java
@@ -68,7 +68,7 @@ import static org.springframework.cloud.stream.app.plugin.utils.MavenModelUtils.
 @Mojo(name = "generate-app")
 public class SpringCloudStreamAppMojo extends AbstractMojo {
 
-	private static final String SPRING_CLOUD_STREAM_BINDER_GROUP_ID = "org.springframework.cloud";
+    private static final String SPRING_CLOUD_STREAM_BINDER_GROUP_ID = "org.springframework.cloud";
 
 	private static final String SPRING_APPLICATION_NAME = "spring.application.name";
 
@@ -81,8 +81,9 @@ public class SpringCloudStreamAppMojo extends AbstractMojo {
 	private static final String MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE = "management.endpoints.web.exposure.include";
 
 	private static final String SPRING_AUTOCONFIGURE_EXCLUDE = "spring.autoconfigure.exclude";
+    public static final String DOCKER_HUB_ORG = "docker.hub.org";
 
-	@Parameter(defaultValue="${project}", readonly=true, required=true)
+    @Parameter(defaultValue="${project}", readonly=true, required=true)
 	private MavenProject project;
 
 	@Parameter
@@ -152,13 +153,6 @@ public class SpringCloudStreamAppMojo extends AbstractMojo {
 			this.additionalPlugins.add(MavenModelUtils.getMavenDependencyPlugin(this.copyResources));
 		}
 
-		if (StringUtils.isEmpty(dockerHubOrg)) {
-			projectGenerator.setDockerHubOrg("springcloud" + applicationType);
-		}
-		else {
-			projectGenerator.setDockerHubOrg(dockerHubOrg);
-		}
-
 		if (!entrypointType.equals(ENTRYPOINT_TYPE_EXEC)
 				&& !entrypointType.equals(ENTRYPOINT_TYPE_SHELL)) {
 			throw new MojoFailureException(
@@ -167,7 +161,6 @@ public class SpringCloudStreamAppMojo extends AbstractMojo {
 		}
 		getLog().info("Generating apps with entrypointType: " + entrypointType);
 
-		projectGenerator.setDockerHubOrg("springcloud" + applicationType);
 		projectGenerator.setBomsWithHigherPrecedence(bomsWithHigherPrecedence);
 		projectGenerator.setAdditionalBoms(additionalBoms);
 		projectGenerator.setAdditionalPlugins(additionalPlugins);
@@ -186,6 +179,16 @@ public class SpringCloudStreamAppMojo extends AbstractMojo {
 					.stream()
 					.filter(p -> !mavenProject.getParent().getProperties().containsKey(p))
 					.forEach(p -> properties.put(p, mavenProject.getProperties().get(p)));
+
+			// Add docker organisation as property instead of hard coding into plugin configuration for more flexibility
+			if(!properties.containsKey(DOCKER_HUB_ORG)) {
+				if (StringUtils.isEmpty(dockerHubOrg)) {
+					properties.put("docker.hub.org",  "springcloud" + applicationType);
+				}
+		        else {
+					properties.put("docker.hub.org", dockerHubOrg);
+		        }
+			}
 
 			projectGenerator.setProperties(properties);
 		}

--- a/spring-cloud-stream-app-maven-plugin/src/main/java/org/springframework/cloud/stream/app/plugin/utils/MavenModelUtils.java
+++ b/spring-cloud-stream-app-maven-plugin/src/main/java/org/springframework/cloud/stream/app/plugin/utils/MavenModelUtils.java
@@ -216,6 +216,9 @@ public class MavenModelUtils {
         final Xpp3Dom build = SpringCloudStreamPluginUtils.addElement(image, "build");
         SpringCloudStreamPluginUtils.addElement(build, "from", "springcloud/openjdk");
 
+        final Xpp3Dom tags = SpringCloudStreamPluginUtils.addElement(build, "tags");
+        SpringCloudStreamPluginUtils.addElement(tags, "tag", version);
+
         final Xpp3Dom volumes = SpringCloudStreamPluginUtils.addElement(build, "volumes");
         SpringCloudStreamPluginUtils.addElement(volumes, "volume", "/tmp");
 

--- a/spring-cloud-stream-app-maven-plugin/src/main/java/org/springframework/cloud/stream/app/plugin/utils/MavenModelUtils.java
+++ b/spring-cloud-stream-app-maven-plugin/src/main/java/org/springframework/cloud/stream/app/plugin/utils/MavenModelUtils.java
@@ -185,7 +185,7 @@ public class MavenModelUtils {
         }
     }
 
-    public static void addDockerPlugin(String artifactId, String version, String dockerHubOrg, InputStream is, OutputStream os, String entrypointStyle) throws IOException {
+    public static void addDockerPlugin(String artifactId, String version, InputStream is, OutputStream os, String entrypointStyle) throws IOException {
         final MavenXpp3Reader reader = new MavenXpp3Reader();
 
         Model pomModel;
@@ -199,7 +199,7 @@ public class MavenModelUtils {
         final Plugin dockerPlugin = new Plugin();
         dockerPlugin.setGroupId("io.fabric8");
         dockerPlugin.setArtifactId("docker-maven-plugin");
-        dockerPlugin.setVersion("0.14.2");
+        dockerPlugin.setVersion("0.30.0");
 
         final Xpp3Dom mavenPluginConfiguration = new Xpp3Dom("configuration");
 
@@ -207,10 +207,10 @@ public class MavenModelUtils {
 
         final Xpp3Dom image = SpringCloudStreamPluginUtils.addElement(images, "image");
         if (!version.endsWith("BUILD-SNAPSHOT")) {
-            SpringCloudStreamPluginUtils.addElement(image, "name", dockerHubOrg + "/${project.artifactId}:" + version);
+            SpringCloudStreamPluginUtils.addElement(image, "name", "${docker.hub.org}/${project.artifactId}:" + version);
         }
         else {
-            SpringCloudStreamPluginUtils.addElement(image, "name", dockerHubOrg + "/${project.artifactId}");
+            SpringCloudStreamPluginUtils.addElement(image, "name",  "${docker.hub.org}/${project.artifactId}");
         }
 
         final Xpp3Dom build = SpringCloudStreamPluginUtils.addElement(image, "build");

--- a/spring-cloud-stream-app-maven-plugin/src/main/java/org/springframework/cloud/stream/app/plugin/utils/MavenModelUtils.java
+++ b/spring-cloud-stream-app-maven-plugin/src/main/java/org/springframework/cloud/stream/app/plugin/utils/MavenModelUtils.java
@@ -345,21 +345,21 @@ public class MavenModelUtils {
         }
     }
 
-    public static void addDistributionManagement(Model pomModel) {
-        DistributionManagement distributionManagement = new DistributionManagement();
+    public static void addDistributionManagement(Model pomModel, DistributionManagement distributionManagement) {
+        if(distributionManagement == null) {
+            distributionManagement = new DistributionManagement();
+            DeploymentRepository releaseRepo = new DeploymentRepository();
+            releaseRepo.setId("repo.spring.io");
+            releaseRepo.setName("Spring Release Repository");
+            releaseRepo.setUrl("https://repo.spring.io/libs-release-local");
+            distributionManagement.setRepository(releaseRepo);
 
-        DeploymentRepository releaseRepo = new DeploymentRepository();
-        releaseRepo.setId("repo.spring.io");
-        releaseRepo.setName("Spring Release Repository");
-        releaseRepo.setUrl("https://repo.spring.io/libs-release-local");
-        distributionManagement.setRepository(releaseRepo);
-
-        DeploymentRepository snapshotRepo = new DeploymentRepository();
-        snapshotRepo.setId("repo.spring.io");
-        snapshotRepo.setName("Spring Snapshot Repository");
-        snapshotRepo.setUrl("https://repo.spring.io/libs-snapshot-local");
-        distributionManagement.setSnapshotRepository(snapshotRepo);
-
+            DeploymentRepository snapshotRepo = new DeploymentRepository();
+            snapshotRepo.setId("repo.spring.io");
+            snapshotRepo.setName("Spring Snapshot Repository");
+            snapshotRepo.setUrl("https://repo.spring.io/libs-snapshot-local");
+            distributionManagement.setSnapshotRepository(snapshotRepo);
+        }
         pomModel.setDistributionManagement(distributionManagement);
     }
 

--- a/spring-cloud-stream-app-maven-plugin/src/main/java/org/springframework/cloud/stream/app/plugin/utils/MavenModelUtils.java
+++ b/spring-cloud-stream-app-maven-plugin/src/main/java/org/springframework/cloud/stream/app/plugin/utils/MavenModelUtils.java
@@ -68,7 +68,7 @@ public class MavenModelUtils {
         build.addPlugin(plugin);
     }
 
-    public static Model getModelFromContainerPom(File genProjecthome, String groupId, String version) throws IOException, XmlPullParserException {
+    public static Model getModelFromContainerPom(File genProjecthome, String groupId, String version, DistributionManagement distributionManagement) throws IOException, XmlPullParserException {
         File pom = new File(genProjecthome, "pom.xml");
         Model model = pom.exists() ? getModel(pom) : null;
         if (model != null) {
@@ -119,35 +119,37 @@ public class MavenModelUtils {
             developers.add(developer);
             model.setDevelopers(developers);
 
-            DistributionManagement distributionManagement = new DistributionManagement();
 
-            DeploymentRepository releaseRepo = new DeploymentRepository();
-            releaseRepo.setId("repo.spring.io");
-            releaseRepo.setName("Spring Release Repository");
-            releaseRepo.setUrl("https://repo.spring.io/libs-release-local");
-            distributionManagement.setRepository(releaseRepo);
+            if(distributionManagement == null) {
+                distributionManagement = new DistributionManagement();
 
-            DeploymentRepository snapshotRepo = new DeploymentRepository();
-            snapshotRepo.setId("repo.spring.io");
-            snapshotRepo.setName("Spring Snapshot Repository");
-            snapshotRepo.setUrl("https://repo.spring.io/libs-snapshot-local");
-            distributionManagement.setSnapshotRepository(snapshotRepo);
+                DeploymentRepository releaseRepo = new DeploymentRepository();
+                releaseRepo.setId("repo.spring.io");
+                releaseRepo.setName("Spring Release Repository");
+                releaseRepo.setUrl("https://repo.spring.io/libs-release-local");
+                distributionManagement.setRepository(releaseRepo);
 
+                DeploymentRepository snapshotRepo = new DeploymentRepository();
+                snapshotRepo.setId("repo.spring.io");
+                snapshotRepo.setName("Spring Snapshot Repository");
+                snapshotRepo.setUrl("https://repo.spring.io/libs-snapshot-local");
+                distributionManagement.setSnapshotRepository(snapshotRepo);
+
+                Profile profile = new Profile();
+                profile.setId("milestone");
+                DistributionManagement milestoneDistManagement = new DistributionManagement();
+
+                DeploymentRepository milestoneRepo = new DeploymentRepository();
+                milestoneRepo.setId("repo.spring.io");
+                milestoneRepo.setName("Spring Milestone Repository");
+                milestoneRepo.setUrl("https://repo.spring.io/libs-milestone-local");
+                milestoneDistManagement.setRepository(milestoneRepo);
+                profile.setDistributionManagement(milestoneDistManagement);
+                List<Profile> profiles = new ArrayList<>();
+                profiles.add(profile);
+                model.setProfiles(profiles);
+            }
             model.setDistributionManagement(distributionManagement);
-
-            Profile profile = new Profile();
-            profile.setId("milestone");
-            DistributionManagement milestoneDistManagement = new DistributionManagement();
-
-            DeploymentRepository milestoneRepo = new DeploymentRepository();
-            milestoneRepo.setId("repo.spring.io");
-            milestoneRepo.setName("Spring Milestone Repository");
-            milestoneRepo.setUrl("https://repo.spring.io/libs-milestone-local");
-            milestoneDistManagement.setRepository(milestoneRepo);
-            profile.setDistributionManagement(milestoneDistManagement);
-            List<Profile> profiles = new ArrayList<>();
-            profiles.add(profile);
-            model.setProfiles(profiles);
 
             getBuildWithDockerPluginDefinition(model);
         }


### PR DESCRIPTION
The maven plugin is a wonderfull peace of kit I use to create Spring Cloud Streams and Tasks without binding myself to either kafka or rabbit mq. 

However, when testing this plugin in my closed environment for sources that are project specific, the generated projects consisted of many hard coded defaults that are not applicable to my project. 

I have make the Distribution Management and docker hub organisation configurable through properties and configuration to adopt use of this excellent maven plugin in  projects 