### PR TITLE
Added pubsub option to binders tag

### DIFF
--- a/spring-cloud-stream-app-maven-plugin/src/main/java/org/springframework/cloud/stream/app/plugin/generator/ProjectGenerator.java
+++ b/spring-cloud-stream-app-maven-plugin/src/main/java/org/springframework/cloud/stream/app/plugin/generator/ProjectGenerator.java
@@ -96,6 +96,12 @@ public class ProjectGenerator {
 		appTemplateProperties.put("app-package-name", appPackageName);
 		appTemplateProperties.put("app-binder", binder);
 
+		if("pubsub".equals(binder)) {
+			appTemplateProperties.put("app-binder-artifact", "spring-cloud-gcp-pubsub-stream-binder");
+		} else {
+			appTemplateProperties.put("app-binder-artifact", "spring-cloud-stream-binder-" + binder);
+		}
+
 		// app POM
 		File appDir =
 				mkdirs(file(appRootDirectory, appDefinition.getName() + "-" + appDefinition.getType() + "-" + binder));

--- a/spring-cloud-stream-app-maven-plugin/src/main/resources/template/app-pom.xml
+++ b/spring-cloud-stream-app-maven-plugin/src/main/resources/template/app-pom.xml
@@ -52,7 +52,8 @@
 		<!-- (end) additional dependencies -->
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-binder-{{app-binder}}</artifactId>
+			<!--<artifactId>spring-cloud-stream-binder-{{app-binder}}</artifactId>-->
+			<artifactId>{{app-binder-artifact}}</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
I've added "pubsub" as an option for the binder. 
Given that the pubsub binder dependency name does not follow the "spring-cloud-stream-binder-{{binder}}" syntax, I've added a dedicated handling of that option.